### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/maxwellkemp10-ux/stonewall-showcase/security/code-scanning/3](https://github.com/maxwellkemp10-ux/stonewall-showcase/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/verify.yml` so all jobs in this workflow inherit least-privilege token access.

Best fix (minimal, no functionality change):
- In `.github/workflows/verify.yml`, insert immediately after the `on:` trigger section (before `jobs:`):
  - `permissions:`
  - `  contents: read`

This is sufficient for `actions/checkout` and test execution in the shown steps, and avoids granting unnecessary write scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
