### PR TITLE
Potential fix for code scanning alert no. 2: Replacement of a substring with itself

### DIFF
--- a/scripts/qc_sweep.mjs
+++ b/scripts/qc_sweep.mjs
@@ -50,7 +50,7 @@ for (const e of emails) {
   // Extract claim numbers from subject lines (AB505XXXXXX or P505XXXXXX patterns)
   const claims = subj.match(/[A-Z]{1,2}505\d{5,7}/gi) || [];
   for (const cl of claims) {
-    const key = cl.toUpperCase().replace(/^AB505/, 'AB505').replace(/-/g, '');
+    const key = cl.toUpperCase().replace(/-/g, '');
     if (!emailsByClaim.has(key)) emailsByClaim.set(key, []);
     emailsByClaim.get(key).push(e);
   }


### PR DESCRIPTION
Potential fix for [https://github.com/maxwellkemp10-ux/stonewall-showcase/security/code-scanning/2](https://github.com/maxwellkemp10-ux/stonewall-showcase/security/code-scanning/2)

The fix is to remove the no-op replacement from the claim-key normalization pipeline.

Best minimal fix without changing functionality:
- In `scripts/qc_sweep.mjs`, line 53 region, change:
  - from: `cl.toUpperCase().replace(/^AB505/, 'AB505').replace(/-/g, '')`
  - to: `cl.toUpperCase().replace(/-/g, '')`
- No imports, new methods, or new dependencies are needed.

This preserves current runtime behavior (since the flagged replacement had no effect) while eliminating the CodeQL issue and making the intent clearer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
