### PR TITLE
feat(docs-drift): daily watcher that flags stale docs against merged PRs

### DIFF
--- a/.docs-drift/README.md
+++ b/.docs-drift/README.md
@@ -1,0 +1,13 @@
+# `.docs-drift/`
+
+State and configuration for the **Docs Drift Watcher** — the daily
+schedule that keeps the documentation honest about what the code does.
+
+| File | Owner | Purpose |
+| --- | --- | --- |
+| `config.yml` | Humans | Globs, ignore lists, thresholds. |
+| `state.json` | The watcher | Last-run checkpoint. Bumped only when the watcher's PR is merged. |
+| `last-run.json` | The watcher | Per-run summary; uploaded as a CI artifact. |
+
+The full design and operating notes live at
+[`docs/overview/docs-drift-watcher.md`](../docs/overview/docs-drift-watcher.md).

--- a/.docs-drift/config.yml
+++ b/.docs-drift/config.yml
@@ -1,0 +1,26 @@
+# docs-drift-watcher configuration
+#
+# Tiny key:value / key:[a,b,c] file consumed by scripts/docs_drift_watcher.py.
+# Keep it simple — no nested structures, no anchors. The script ships
+# sensible defaults; this file just lets you tune them in-repo.
+
+# Which files in docs/ count as documentation.
+docs_globs: [**/*.md, **/*.html, **/*.mdx]
+
+# Which files in merged PRs the scanner reads as "API surface."
+code_extensions: [.py, .mjs, .js, .ts, .tsx, .jsx]
+
+# Symbols too generic to be useful drift signals — ignored on match.
+ignore_symbols: [self, cls, main, test, setUp, tearDown, render, create, delete, get, set, list, post, put, update, value, items, data, render_report, render_banner]
+
+# Below this length (and not a route), symbols are treated as noise.
+min_symbol_length: 5
+
+# Subtrees inside docs/ that are themselves machine-generated — skip them.
+ignore_doc_paths: [docs/_drift/, docs/portal/data/]
+
+# Cap per run so a backlog of merges does not blow the API budget.
+max_prs_per_run: 50
+
+# The base branch we treat as "production docs."
+base_branch: main

--- a/.docs-drift/state.json
+++ b/.docs-drift/state.json
@@ -1,0 +1,6 @@
+{
+  "last_run_utc": null,
+  "last_pr_number": 0,
+  "last_window_pr_count": 0,
+  "last_window_hits": 0
+}

--- a/.github/workflows/docs-drift-watcher.yml
+++ b/.github/workflows/docs-drift-watcher.yml
@@ -48,19 +48,19 @@ jobs:
           SINCE: ${{ inputs.since }}
         run: |
           set -euo pipefail
-          SINCE_ARG=""
+          ARGS=(
+            --repo "${{ github.repository }}"
+            --docs-root docs
+            --state .docs-drift/state.json
+            --config .docs-drift/config.yml
+            --report-dir docs/_drift
+            --output .docs-drift/last-run.json
+            --apply-banners
+          )
           if [ -n "${SINCE:-}" ]; then
-            SINCE_ARG="--since ${SINCE}"
+            ARGS+=(--since "${SINCE}")
           fi
-          python scripts/docs_drift_watcher.py \
-            --repo "${{ github.repository }}" \
-            --docs-root docs \
-            --state .docs-drift/state.json \
-            --config .docs-drift/config.yml \
-            --report-dir docs/_drift \
-            --output .docs-drift/last-run.json \
-            --apply-banners \
-            ${SINCE_ARG}
+          python scripts/docs_drift_watcher.py "${ARGS[@]}"
 
       - name: Read run summary
         id: summary
@@ -84,6 +84,8 @@ jobs:
           path: .docs-drift/last-run.json
           retention-days: 30
 
+      # Checkpoint in .docs-drift/state.json advances when this drift PR
+      # merges to main — not on clean runs (intentional; see design doc).
       - name: Open or refresh review PR
         if: steps.summary.outputs.detected == 'true'
         env:

--- a/.github/workflows/docs-drift-watcher.yml
+++ b/.github/workflows/docs-drift-watcher.yml
@@ -1,0 +1,151 @@
+name: Docs Drift Watcher
+
+# Daily surveillance for documentation drift.
+#
+# Reads merged PRs since the last successful run, extracts the API
+# symbols those PRs touched, scans every doc page for references to
+# them, and — if any are found — opens (or refreshes) a single
+# review PR with inline editor banners and a full report.
+
+on:
+  schedule:
+    # 13:17 UTC daily — a few minutes off the top of the hour so we
+    # don't pile onto every other cron-schedule job in the universe.
+    - cron: "17 13 * * *"
+  workflow_dispatch:
+    inputs:
+      since:
+        description: "ISO timestamp to scan from (overrides state file)"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: docs-drift-watcher
+  cancel-in-progress: false
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Scan merged PRs for documentation drift
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SINCE: ${{ inputs.since }}
+        run: |
+          set -euo pipefail
+          SINCE_ARG=""
+          if [ -n "${SINCE:-}" ]; then
+            SINCE_ARG="--since ${SINCE}"
+          fi
+          python scripts/docs_drift_watcher.py \
+            --repo "${{ github.repository }}" \
+            --docs-root docs \
+            --state .docs-drift/state.json \
+            --config .docs-drift/config.yml \
+            --report-dir docs/_drift \
+            --output .docs-drift/last-run.json \
+            --apply-banners \
+            ${SINCE_ARG}
+
+      - name: Read run summary
+        id: summary
+        run: |
+          set -euo pipefail
+          python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json, os
+          data = json.load(open(".docs-drift/last-run.json"))
+          print(f"detected={'true' if data.get('drift_detected') else 'false'}")
+          print(f"hits={len(data.get('hits', []))}")
+          print(f"prs={len(data.get('merged_prs', []))}")
+          print(f"flagged_pages={len(data.get('flagged_docs', []))}")
+          print(f"report_path={data.get('report_path', '')}")
+          PY
+
+      - name: Upload run artifact
+        if: always()
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4
+        with:
+          name: docs-drift-run-${{ github.run_id }}
+          path: .docs-drift/last-run.json
+          retention-days: 30
+
+      - name: Open or refresh review PR
+        if: steps.summary.outputs.detected == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DRIFT_HITS: ${{ steps.summary.outputs.hits }}
+          DRIFT_PRS: ${{ steps.summary.outputs.prs }}
+          DRIFT_PAGES: ${{ steps.summary.outputs.flagged_pages }}
+          REPORT_PATH: ${{ steps.summary.outputs.report_path }}
+        run: |
+          set -euo pipefail
+
+          BRANCH="docs-drift/auto"
+          git config user.name  "docs-drift-watcher[bot]"
+          git config user.email "docs-drift-watcher@users.noreply.github.com"
+
+          # Restart the branch from the current main so each run carries a
+          # clean diff against the editor's review target.
+          git checkout -B "$BRANCH"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No working-tree changes to commit; nothing to do."
+            exit 0
+          fi
+          git commit -m "docs: drift watcher flagged ${DRIFT_HITS} reference(s) from ${DRIFT_PRS} PR(s)"
+          git push --force-with-lease origin "$BRANCH"
+
+          BODY_FILE="$(mktemp)"
+          {
+            echo "## Docs drift review"
+            echo
+            echo "The daily watcher matched **${DRIFT_HITS}** documentation reference(s)"
+            echo "against **${DRIFT_PRS}** recently merged PR(s), touching"
+            echo "**${DRIFT_PAGES}** page(s)."
+            echo
+            echo "Each flagged page now carries a \`DOCS-DRIFT\` editor banner pointing"
+            echo "at the relevant PRs. An editor should:"
+            echo
+            echo "1. Open every flagged page."
+            echo "2. Confirm the content still matches the updated API."
+            echo "3. Edit the page if needed."
+            echo "4. Delete the \`DOCS-DRIFT\` banner block."
+            echo "5. Merge."
+            echo
+            echo "---"
+            echo
+            if [ -n "${REPORT_PATH:-}" ] && [ -f "${REPORT_PATH}" ]; then
+              cat "${REPORT_PATH}"
+            fi
+          } > "$BODY_FILE"
+
+          TITLE="docs: drift watcher review ($(date -u +%Y-%m-%d))"
+          EXISTING="$(gh pr list --head "$BRANCH" --state open \
+                        --json number --jq '.[0].number' || true)"
+          if [ -n "$EXISTING" ]; then
+            gh pr edit "$EXISTING" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE"
+            echo "Refreshed PR #${EXISTING}."
+          else
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "$TITLE" \
+              --body-file "$BODY_FILE"
+          fi

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -30,7 +30,7 @@ jobs:
         run: node --test tests/qb1_tracker_helpers.test.mjs tests/email_consolidator.test.mjs
 
       - name: Run Python tests
-        run: python -m unittest tests.test_ingest_onedrive tests.test_verify_repo_consistency tests.test_sample_corpus
+        run: python -m unittest tests.test_ingest_onedrive tests.test_verify_repo_consistency tests.test_sample_corpus tests.test_docs_drift_watcher
 
       - name: Showcase voice guard
         run: python scripts/check_showcase_voice.py

--- a/docs/overview/docs-drift-watcher.md
+++ b/docs/overview/docs-drift-watcher.md
@@ -1,0 +1,259 @@
+# Docs Drift Watcher
+
+**A daily, autonomous editor that catches stale documentation the moment
+your API moves out from under it.**
+
+> Code ships fast. Documentation does not. The Docs Drift Watcher closes
+> that gap before it becomes a support ticket, a misled customer, or a
+> bad demo.
+
+---
+
+## The problem
+
+Documentation rot is a slow leak. Engineers rename a function, retire a
+route, change a parameter shape — and the page that taught the world how
+to use it sits there, smiling, lying. Nobody notices until a reader does.
+
+The leak compounds in any repo that ships more than once a week. You
+cannot fix it by asking authors to "remember the docs," and you should
+not fix it by gating every PR on a manual doc review. You fix it with a
+scheduled, deterministic surveillance layer that knows what changed and
+where it is mentioned.
+
+That layer is the Docs Drift Watcher.
+
+---
+
+## What it does
+
+Every day at **13:17 UTC**, the watcher runs five steps in order:
+
+1. **Reads the checkpoint.** Opens `.docs-drift/state.json` and learns
+   the timestamp and PR number of the last successful run.
+2. **Lists merged PRs.** Asks GitHub for everything merged into the base
+   branch since that checkpoint, newest first, capped at the configured
+   budget.
+3. **Extracts API symbols.** Walks each changed code file's unified diff
+   and pulls out function names, class names, exported identifiers, and
+   route patterns — the things readers actually cite in documentation.
+4. **Scans every doc page.** Word-boundary matches each symbol against
+   every Markdown, HTML, and MDX file under `docs/`. Generic noise is
+   filtered through a configurable ignore list.
+5. **Opens a review PR.** Writes a dated drift report into
+   `docs/_drift/`, drops an inline editor banner at the top of every
+   flagged page, and either opens a new PR or refreshes the standing one
+   at `docs-drift/auto`.
+
+The editor sees a single, opinionated PR with every flagged page in one
+diff and a clean checklist of what to verify.
+
+---
+
+## Architecture
+
+```text
+schedule (13:17 UTC)
+        |
+        v
+   GitHub Actions runner ──── reads .docs-drift/state.json
+        |                              |
+        |                              v
+        |                    GitHub API: merged PRs
+        |                              |
+        |                              v
+        |                    AST + regex symbol extractor
+        |                              |
+        |                              v
+        |                    glob walk over docs/
+        |                              |
+        |                              v
+        |                    drift report + inline banners
+        |                              |
+        v                              v
+   force-push docs-drift/auto ──> open / refresh review PR
+        |
+        v
+   editor reviews → merges → state.json advances on main
+```
+
+The state checkpoint is intentionally stored in-repo. It only advances
+when the watcher's PR is merged, which means an unattended drift PR
+keeps presenting new merges in the same review surface — no silent
+gaps, no exponential backoff games.
+
+---
+
+## File map
+
+| Path | Role |
+| --- | --- |
+| `.github/workflows/docs-drift-watcher.yml` | Schedule trigger, runner, PR plumbing. |
+| `scripts/docs_drift_watcher.py` | Single-file scanner. Stdlib only. |
+| `.docs-drift/config.yml` | Globs, ignore lists, thresholds. |
+| `.docs-drift/state.json` | Last-run checkpoint (committed). |
+| `.docs-drift/last-run.json` | Per-run summary (artifact + commit). |
+| `docs/_drift/REPORT-YYYY-MM-DD.md` | Dated, human-readable drift report. |
+| `tests/test_docs_drift_watcher.py` | Symbol extraction + doc matching coverage. |
+
+---
+
+## What the editor sees
+
+Every flagged page gets a banner injected at the very top, between
+sentinel comments. It looks like this:
+
+```markdown
+<!-- DOCS-DRIFT:BEGIN -->
+> **Documentation drift detected** _(scanned 2026-05-21T13:17:00Z)_
+>
+> The watcher matched API symbols that changed in recently merged PRs
+> against this page. Confirm the page is still accurate, edit if
+> needed, then remove this banner.
+>
+> - **#482** — Rename `IngestPipeline` to `CorpusPipeline`
+>   symbols: `IngestPipeline`, `ingest_corpus`
+> - **#487** — Drop legacy `/v1/matters` route
+>   symbols: `/v1/matters`
+<!-- DOCS-DRIFT:END -->
+```
+
+The sentinels are not decoration. The watcher strips any prior banner
+before writing a new one, so reruns never stack. Once the editor deletes
+the banner block and merges, the page returns to a clean state and the
+checkpoint moves forward.
+
+The PR body itself contains the full drift report: scan window, every
+flagged page, every symbol, every merged PR reviewed — so a reviewer can
+audit the watcher's reasoning without leaving GitHub.
+
+---
+
+## How the symbol extractor thinks
+
+It reads diffs, not whole files. A symbol counts as "touched" if it
+appears on a `+` or `-` line in the PR's unified diff. That is the
+single most important design choice — it catches additions, removals,
+**and** renames in the same pass, because a rename shows up as a removed
+old name plus an added new name.
+
+| Language | Strategy |
+| --- | --- |
+| Python (`.py`) | `ast.parse` on the synthesized added+removed body; falls back to a tolerant `def` / `class` regex when the diff fragment is not parseable on its own. |
+| JavaScript / TypeScript (`.mjs`, `.js`, `.ts`, `.tsx`, `.jsx`) | Regex over `export function`, `export class`, `export const`, top-level `function`, and `class` declarations. |
+| HTTP routes (any language) | Regex over `@app.route(...)`, `app.get(...)`, `router.post(...)`, and their siblings. Routes never get length-filtered. |
+
+Private symbols (leading underscore in Python, lower-case `class` names
+in JS) are skipped. Symbols shorter than `min_symbol_length` are skipped
+unless they are routes. The `ignore_symbols` list strips common nouns
+that match too eagerly (`get`, `list`, `update`, …).
+
+---
+
+## Configuration
+
+All knobs live in `.docs-drift/config.yml`. The parser is deliberately
+tiny — flat keys only, lists in `[a, b, c]` form, no anchors.
+
+```yaml
+docs_globs:        [**/*.md, **/*.html, **/*.mdx]
+code_extensions:   [.py, .mjs, .js, .ts, .tsx, .jsx]
+ignore_symbols:    [self, cls, get, set, list, ...]
+min_symbol_length: 5
+ignore_doc_paths:  [docs/_drift/, docs/portal/data/]
+max_prs_per_run:   50
+base_branch:       main
+```
+
+The script ships sane defaults for every key, so an empty config file is
+valid. Local overrides only need to specify the keys you actually want
+to change.
+
+---
+
+## Running it by hand
+
+The workflow exposes `workflow_dispatch` with an optional `since` input:
+
+```text
+Actions → Docs Drift Watcher → Run workflow
+   since: 2026-05-01T00:00:00Z   (optional — overrides state file)
+```
+
+To run it locally against the live repo:
+
+```bash
+export GITHUB_TOKEN="<a fine-grained PAT with PR read access>"
+python scripts/docs_drift_watcher.py \
+  --repo maxwellkemp10-ux/stonewall-showcase \
+  --docs-root docs \
+  --apply-banners \
+  --dry-run
+```
+
+`--dry-run` performs the full scan and prints the summary to stderr
+without writing reports, banners, state, or the summary JSON. Useful
+for tuning `ignore_symbols` against a real backlog.
+
+---
+
+## Operating modes
+
+### Same-repo docs (default)
+
+Documentation lives at `docs/` next to the code. The workflow scans the
+same repo it runs in and opens the review PR there. No extra secrets.
+
+### Cross-repo docs
+
+When documentation lives in a separate repository, pass the docs repo
+through `--docs-repo` and run the workflow from the docs repo with a
+GitHub App token (or fine-grained PAT) that has `contents:read` on the
+source repo and `contents:write` + `pull-requests:write` on the docs
+repo. The scanner still does the matching — the workflow just commits
+to a different remote.
+
+---
+
+## Failure modes, and how the design absorbs them
+
+| Risk | What protects you |
+| --- | --- |
+| API rate-limit during a big backlog | `max_prs_per_run` cap; the next day picks up where this one stopped because state only advances on merge. |
+| False positives on common words | Length floor + `ignore_symbols` + word-boundary regex; tunable in-repo. |
+| Stacked banners on repeated runs | Sentinel comments scope the banner block; each rerun strips the prior one before writing a new one. |
+| Concurrent runs racing | `concurrency: docs-drift-watcher` group prevents two scans pushing to the same branch. |
+| Drift PR sitting unmerged | Workflow refreshes the same `docs-drift/auto` branch each day — the open PR keeps accumulating new symbols until it is merged. |
+
+---
+
+## Why this design, not the alternatives
+
+- **Why not block every code PR on doc edits?** Wrong loop. The
+  engineer writing the code is rarely the right author for the doc
+  change, and blocking PRs trains everyone to write tiny throwaway doc
+  edits to get green. This watcher moves the work to a dedicated
+  editor surface where docs get the attention they deserve.
+
+- **Why not a vector-similarity model over the doc corpus?** Overkill
+  for the failure mode that matters. Drift is overwhelmingly about
+  named identifiers, and a word-boundary symbol match catches the
+  things that actually break readers. The model would add latency,
+  cost, and a new failure surface in exchange for catches we do not
+  need.
+
+- **Why one rolling PR instead of one PR per drift event?** Reviewer
+  ergonomics. A standing PR is a single tab to keep open and a single
+  diff to review. New events accumulate into the same surface until
+  it is cleared.
+
+---
+
+## Status
+
+- Schedule: daily at **13:17 UTC** plus manual dispatch.
+- Dependencies: Python 3.12, GitHub Actions runner, `GITHUB_TOKEN`.
+  No third-party Python packages.
+- Footprint: one workflow, one script, one config file, one state
+  file. Deletable in a single commit if it ever stops earning its
+  keep.

--- a/docs/overview/docs-drift-watcher.md
+++ b/docs/overview/docs-drift-watcher.md
@@ -100,8 +100,9 @@ gaps, no exponential backoff games.
 
 ## What the editor sees
 
-Every flagged page gets a banner injected at the very top, between
-sentinel comments. It looks like this:
+Every flagged page gets a banner injected immediately after any YAML
+frontmatter (or at the top when there is none), between sentinel comments.
+It looks like this:
 
 ```markdown
 <!-- DOCS-DRIFT:BEGIN -->
@@ -206,12 +207,14 @@ same repo it runs in and opens the review PR there. No extra secrets.
 
 ### Cross-repo docs
 
-When documentation lives in a separate repository, pass the docs repo
-through `--docs-repo` and run the workflow from the docs repo with a
-GitHub App token (or fine-grained PAT) that has `contents:read` on the
-source repo and `contents:write` + `pull-requests:write` on the docs
-repo. The scanner still does the matching — the workflow just commits
-to a different remote.
+When documentation lives in a separate repository, run the workflow from
+the docs repo with a GitHub App token (or fine-grained PAT) that has
+`contents:read` on the source repo and `contents:write` +
+`pull-requests:write` on the docs repo. Pass `--docs-repo` so the run
+summary records which remote owns the pages; today the scanner still
+reads `docs/` from the checked-out workspace (same-repo layout). A
+future workflow variant can check out two remotes — the flag is reserved
+for that path.
 
 ---
 
@@ -252,8 +255,9 @@ to a different remote.
 ## Status
 
 - Schedule: daily at **13:17 UTC** plus manual dispatch.
-- Dependencies: Python 3.12, GitHub Actions runner, `GITHUB_TOKEN`.
-  No third-party Python packages.
+- Dependencies: Python **3.12** on the GitHub Actions runner (the script
+  itself is stdlib-only and runs on **3.10+** locally), plus
+  `GITHUB_TOKEN`. No third-party Python packages.
 - Footprint: one workflow, one script, one config file, one state
   file. Deletable in a single commit if it ever stops earning its
   keep.

--- a/scripts/docs_drift_watcher.py
+++ b/scripts/docs_drift_watcher.py
@@ -7,6 +7,7 @@ a drift report plus optional inline editor banners. The companion
 workflow turns that working-tree state into a review PR.
 
 Pure stdlib. No third-party packages. Safe to run anywhere Python 3.10+ runs.
+The scheduled workflow uses Python 3.12 on ubuntu-latest.
 
 Usage:
     python scripts/docs_drift_watcher.py \
@@ -52,6 +53,7 @@ DEFAULT_CONFIG: dict = {
 
 # ---------- config & state ----------
 
+
 def load_config(path: Path) -> dict:
     cfg = dict(DEFAULT_CONFIG)
     if not path.exists():
@@ -91,7 +93,29 @@ def save_state(path: Path, state: dict) -> None:
     path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
 
 
+def parse_iso_timestamp(value: str | None) -> str | None:
+    """Normalize ISO-8601 timestamps to UTC ``...Z`` for comparisons."""
+    if not value:
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid ISO timestamp: {value!r}") from exc
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def escape_markdown_inline(text: str) -> str:
+    """Escape characters that break Markdown inline or link text."""
+    return re.sub(r"([\\`*_{}\[\]()#+\-.!|])", r"\\\1", text)
+
+
 # ---------- GitHub client ----------
+
 
 class GitHub:
     def __init__(self, token: str | None) -> None:
@@ -122,7 +146,6 @@ class GitHub:
         repo: str,
         base_branch: str,
         since_iso: str | None,
-        since_pr: int,
         max_prs: int,
     ) -> list[dict]:
         out: list[dict] = []
@@ -137,20 +160,25 @@ class GitHub:
             batch = self._request(url)
             if not isinstance(batch, list) or not batch:
                 break
-            kept_any = False
             for pr in batch:
                 if not pr.get("merged_at"):
                     continue
-                if since_iso and pr["merged_at"] <= since_iso:
-                    continue
-                if pr["number"] <= since_pr:
+                merged_at = parse_iso_timestamp(pr["merged_at"])
+                if since_iso and merged_at and merged_at <= since_iso:
                     continue
                 out.append(pr)
-                kept_any = True
                 if len(out) >= max_prs:
                     break
-            if not kept_any or len(batch) < 100:
+            if len(out) >= max_prs:
                 break
+            if len(batch) < 100:
+                break
+            if since_iso:
+                oldest_updated = parse_iso_timestamp(
+                    batch[-1].get("updated_at")
+                )
+                if oldest_updated and oldest_updated <= since_iso:
+                    break
             page += 1
         out.sort(key=lambda p: p["merged_at"])
         return out
@@ -174,6 +202,7 @@ class GitHub:
 
 
 # ---------- symbol extraction ----------
+
 
 @dataclass
 class Symbol:
@@ -269,6 +298,7 @@ def _python_regex_fallback(code: str) -> list[tuple[str, str]]:
 
 # ---------- doc scanning ----------
 
+
 @dataclass
 class DocHit:
     doc_path: str
@@ -292,6 +322,24 @@ def iter_docs(
             yield p
 
 
+def _line_contains_symbol(line: str, name: str, kind: str) -> bool:
+    if kind == "route":
+        return name in line
+    return re.search(rf"\b{re.escape(name)}\b", line) is not None
+
+
+def _build_word_symbol_pattern(
+    symbols_by_name: dict[str, Symbol],
+) -> re.Pattern[str] | None:
+    names = [n for n, s in symbols_by_name.items() if s.kind != "route"]
+    if not names:
+        return None
+    names.sort(key=len, reverse=True)
+    return re.compile(
+        rf"\b({'|'.join(re.escape(name) for name in names)})\b"
+    )
+
+
 def scan_doc(
     doc_path: Path, symbols_by_name: dict[str, Symbol]
 ) -> list[DocHit]:
@@ -300,9 +348,21 @@ def scan_doc(
     except UnicodeDecodeError:
         return []
     hits: list[DocHit] = []
+    word_pattern = _build_word_symbol_pattern(symbols_by_name)
+    route_syms = {
+        name: sym for name, sym in symbols_by_name.items() if sym.kind == "route"
+    }
     for i, line in enumerate(text.splitlines(), start=1):
-        for name, sym in symbols_by_name.items():
-            if re.search(rf"\b{re.escape(name)}\b", line):
+        if word_pattern:
+            match = word_pattern.search(line)
+            if match:
+                name = match.group(1)
+                hits.append(DocHit(
+                    str(doc_path), symbols_by_name[name], i, line.strip()[:240]
+                ))
+                continue
+        for name, sym in route_syms.items():
+            if _line_contains_symbol(line, name, sym.kind):
                 hits.append(DocHit(
                     str(doc_path), sym, i, line.strip()[:240]
                 ))
@@ -330,10 +390,9 @@ def render_banner(hits: list[DocHit], run_iso: str) -> str:
         symbols = ", ".join(sorted({
             f"`{h.symbol.name}`" for h in by_pr[pr_number]
         }))
-        rows.append(
-            f"- **#{pr_number}** — {sample.symbol.pr_title}\n"
-            f"  symbols: {symbols}"
-        )
+        title = escape_markdown_inline(sample.symbol.pr_title)
+        rows.append(f"- **#{pr_number}** — {title}")
+        rows.append(f"  symbols: {symbols}")
     return (
         f"{BANNER_BEGIN}\n"
         f"> **Documentation drift detected** _(scanned {run_iso})_\n"
@@ -342,15 +401,27 @@ def render_banner(hits: list[DocHit], run_iso: str) -> str:
         f"PRs against this page. Confirm the page is still accurate, edit "
         f"if needed, then remove this banner.\n"
         f">\n"
-        + "\n".join(f"> {r}" for r in rows)
+        + "\n".join(f"> {line}" for line in rows)
         + f"\n{BANNER_END}\n\n"
     )
 
 
+def _insert_after_frontmatter(text: str, block: str) -> str:
+    stripped = text.lstrip("\ufeff")
+    if stripped.startswith("---"):
+        parts = stripped.split("---", 2)
+        if len(parts) >= 3:
+            return f"---{parts[1]}---\n\n{block}{parts[2].lstrip()}"
+    return block + stripped
+
+
 def apply_banner(doc_path: Path, banner: str) -> bool:
-    text = doc_path.read_text(encoding="utf-8")
+    try:
+        text = doc_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return False
     stripped = _BANNER_RE.sub("", text)
-    new_text = banner + stripped
+    new_text = _insert_after_frontmatter(stripped, banner)
     if new_text == text:
         return False
     doc_path.write_text(new_text, encoding="utf-8")
@@ -393,15 +464,20 @@ def render_report(
         lines.append("")
     lines += ["## Merged PRs scanned", ""]
     for pr in prs:
+        title = escape_markdown_inline(pr["title"])
+        login = escape_markdown_inline(
+            (pr.get("user") or {}).get("login") or "unknown"
+        )
         lines.append(
-            f"- #{pr['number']} — [{pr['title']}]({pr['html_url']}) "
-            f"by @{pr['user']['login']}, merged {pr['merged_at']}"
+            f"- #{pr['number']} — [{title}]({pr['html_url']}) "
+            f"by @{login}, merged {pr['merged_at']}"
         )
     lines.append("")
     return "\n".join(lines)
 
 
 # ---------- orchestration ----------
+
 
 def collect_symbols(
     gh: GitHub,
@@ -449,7 +525,8 @@ def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--repo", required=True, help="owner/name of source repo")
     ap.add_argument("--docs-repo", default=None,
-                    help="owner/name of docs repo (defaults to --repo)")
+                    help="owner/name of docs repo (recorded in summary JSON; "
+                         "same-repo checkout is assumed today)")
     ap.add_argument("--docs-root", default="docs")
     ap.add_argument("--state", default=".docs-drift/state.json")
     ap.add_argument("--config", default=".docs-drift/config.yml")
@@ -467,7 +544,8 @@ def main(argv: list[str] | None = None) -> int:
 
     config = load_config(config_path)
     state = load_state(state_path)
-    since_iso = args.since or state.get("last_run_utc")
+    since_raw = args.since or state.get("last_run_utc")
+    since_iso = parse_iso_timestamp(since_raw) if since_raw else None
     since_pr = int(state.get("last_pr_number") or 0)
 
     token = os.environ.get("GITHUB_TOKEN")
@@ -484,7 +562,6 @@ def main(argv: list[str] | None = None) -> int:
         args.repo,
         base_branch=str(config.get("base_branch") or "main"),
         since_iso=since_iso,
-        since_pr=since_pr,
         max_prs=int(config.get("max_prs_per_run") or 50),
     )
     print(f"[drift] merged PRs in window: {len(prs)}", file=sys.stderr)

--- a/scripts/docs_drift_watcher.py
+++ b/scripts/docs_drift_watcher.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python3
+"""docs_drift_watcher.py — daily documentation drift surveillance.
+
+Scans merged PRs since the last run, extracts the API symbols touched
+in those PRs, flags docs pages that reference any of them, and writes
+a drift report plus optional inline editor banners. The companion
+workflow turns that working-tree state into a review PR.
+
+Pure stdlib. No third-party packages. Safe to run anywhere Python 3.10+ runs.
+
+Usage:
+    python scripts/docs_drift_watcher.py \
+        --repo maxwellkemp10-ux/stonewall-showcase \
+        --docs-root docs \
+        --apply-banners
+
+Environment:
+    GITHUB_TOKEN — required for non-trivial API usage (rate-limited otherwise).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+GITHUB_API = "https://api.github.com"
+
+DEFAULT_CONFIG: dict = {
+    "docs_globs": ["**/*.md", "**/*.html", "**/*.mdx"],
+    "code_extensions": [".py", ".mjs", ".js", ".ts", ".tsx", ".jsx"],
+    "ignore_symbols": [
+        "self", "cls", "main", "test", "setUp", "tearDown",
+        "render", "create", "delete", "get", "set", "list",
+        "post", "put", "update", "value", "items", "data",
+    ],
+    "min_symbol_length": 5,
+    "ignore_doc_paths": ["docs/_drift/", "docs/portal/data/"],
+    "max_prs_per_run": 50,
+    "base_branch": "main",
+}
+
+
+# ---------- config & state ----------
+
+def load_config(path: Path) -> dict:
+    cfg = dict(DEFAULT_CONFIG)
+    if not path.exists():
+        return _normalize(cfg)
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        key = key.strip()
+        value = value.strip()
+        if value.startswith("[") and value.endswith("]"):
+            items = [v.strip().strip("\"'") for v in value[1:-1].split(",")
+                     if v.strip()]
+            cfg[key] = items
+        elif value.isdigit():
+            cfg[key] = int(value)
+        elif value:
+            cfg[key] = value.strip("\"'")
+    return _normalize(cfg)
+
+
+def _normalize(cfg: dict) -> dict:
+    if isinstance(cfg.get("ignore_symbols"), list):
+        cfg["ignore_symbols"] = set(cfg["ignore_symbols"])
+    return cfg
+
+
+def load_state(path: Path) -> dict:
+    if not path.exists():
+        return {"last_run_utc": None, "last_pr_number": 0}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def save_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+# ---------- GitHub client ----------
+
+class GitHub:
+    def __init__(self, token: str | None) -> None:
+        self.token = token
+
+    def _request(self, url: str) -> list | dict:
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "docs-drift-watcher",
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        req = Request(url, headers=headers)
+        try:
+            with urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read())
+        except HTTPError as exc:
+            body = exc.read().decode("utf-8", "replace")
+            if exc.code == 403 and "rate limit" in body.lower():
+                raise SystemExit(
+                    "GitHub rate limit hit — provide GITHUB_TOKEN."
+                ) from exc
+            raise
+
+    def list_merged_prs(
+        self,
+        repo: str,
+        base_branch: str,
+        since_iso: str | None,
+        since_pr: int,
+        max_prs: int,
+    ) -> list[dict]:
+        out: list[dict] = []
+        page = 1
+        while page <= 10 and len(out) < max_prs:
+            url = (
+                f"{GITHUB_API}/repos/{repo}/pulls"
+                f"?state=closed&base={base_branch}"
+                f"&sort=updated&direction=desc"
+                f"&per_page=100&page={page}"
+            )
+            batch = self._request(url)
+            if not isinstance(batch, list) or not batch:
+                break
+            kept_any = False
+            for pr in batch:
+                if not pr.get("merged_at"):
+                    continue
+                if since_iso and pr["merged_at"] <= since_iso:
+                    continue
+                if pr["number"] <= since_pr:
+                    continue
+                out.append(pr)
+                kept_any = True
+                if len(out) >= max_prs:
+                    break
+            if not kept_any or len(batch) < 100:
+                break
+            page += 1
+        out.sort(key=lambda p: p["merged_at"])
+        return out
+
+    def list_pr_files(self, repo: str, pr_number: int) -> list[dict]:
+        out: list[dict] = []
+        page = 1
+        while page <= 10:
+            url = (
+                f"{GITHUB_API}/repos/{repo}/pulls/{pr_number}/files"
+                f"?per_page=100&page={page}"
+            )
+            batch = self._request(url)
+            if not isinstance(batch, list) or not batch:
+                break
+            out.extend(batch)
+            if len(batch) < 100:
+                break
+            page += 1
+        return out
+
+
+# ---------- symbol extraction ----------
+
+@dataclass
+class Symbol:
+    name: str
+    kind: str
+    source_file: str
+    pr_number: int
+    pr_title: str
+    pr_url: str
+
+
+_JS_EXPORT = re.compile(
+    r"^\s*export\s+(?:async\s+)?(?:function|class|const|let)\s+([A-Za-z_][\w]*)",
+    re.MULTILINE,
+)
+_JS_FN = re.compile(
+    r"^\s*(?:async\s+)?function\s+([A-Za-z_][\w]*)", re.MULTILINE
+)
+_JS_CLASS = re.compile(r"^\s*class\s+([A-Z][\w]*)", re.MULTILINE)
+_ROUTE = re.compile(
+    r"""(?:@app\.route|app\.(?:get|post|put|patch|delete)|"""
+    r"""router\.(?:get|post|put|patch|delete))\(\s*['\"]([^'\"]+)['\"]""",
+    re.IGNORECASE,
+)
+
+
+def extract_python_symbols(code: str) -> list[tuple[str, str]]:
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+    out: list[tuple[str, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not node.name.startswith("_"):
+                out.append((node.name, "function"))
+        elif isinstance(node, ast.ClassDef):
+            out.append((node.name, "class"))
+    return out
+
+
+def extract_js_symbols(code: str) -> list[tuple[str, str]]:
+    found: dict[str, str] = {}
+    for name in _JS_EXPORT.findall(code):
+        found[name] = "export"
+    for name in _JS_FN.findall(code):
+        found.setdefault(name, "function")
+    for name in _JS_CLASS.findall(code):
+        found.setdefault(name, "class")
+    return list(found.items())
+
+
+def extract_routes(code: str) -> list[tuple[str, str]]:
+    return [(path, "route") for path in set(_ROUTE.findall(code))]
+
+
+def extract_from_patch(filename: str, patch: str | None) -> list[tuple[str, str]]:
+    if not patch:
+        return []
+    added_lines: list[str] = []
+    removed_lines: list[str] = []
+    for line in patch.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            added_lines.append(line[1:])
+        elif line.startswith("-") and not line.startswith("---"):
+            removed_lines.append(line[1:])
+    body = "\n".join(added_lines + removed_lines)
+    if filename.endswith(".py"):
+        symbols = extract_python_symbols(body)
+        if not symbols:
+            symbols = _python_regex_fallback(body)
+    elif filename.endswith((".mjs", ".js", ".ts", ".tsx", ".jsx")):
+        symbols = extract_js_symbols(body)
+    else:
+        symbols = []
+    symbols.extend(extract_routes(body))
+    return symbols
+
+
+_PY_DEF = re.compile(r"^\s*(?:async\s+)?def\s+([A-Za-z_][\w]*)", re.MULTILINE)
+_PY_CLASS = re.compile(r"^\s*class\s+([A-Z][\w]*)", re.MULTILINE)
+
+
+def _python_regex_fallback(code: str) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for name in _PY_DEF.findall(code):
+        if not name.startswith("_"):
+            out.append((name, "function"))
+    for name in _PY_CLASS.findall(code):
+        out.append((name, "class"))
+    return out
+
+
+# ---------- doc scanning ----------
+
+@dataclass
+class DocHit:
+    doc_path: str
+    symbol: Symbol
+    line_number: int
+    excerpt: str
+
+
+def iter_docs(
+    root: Path, globs: list[str], ignore_prefixes: list[str]
+) -> Iterator[Path]:
+    seen: set[Path] = set()
+    for pat in globs:
+        for p in root.glob(pat):
+            if not p.is_file() or p in seen:
+                continue
+            seen.add(p)
+            rel = str(p).replace("\\", "/")
+            if any(rel.startswith(prefix) for prefix in ignore_prefixes):
+                continue
+            yield p
+
+
+def scan_doc(
+    doc_path: Path, symbols_by_name: dict[str, Symbol]
+) -> list[DocHit]:
+    try:
+        text = doc_path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return []
+    hits: list[DocHit] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        for name, sym in symbols_by_name.items():
+            if re.search(rf"\b{re.escape(name)}\b", line):
+                hits.append(DocHit(
+                    str(doc_path), sym, i, line.strip()[:240]
+                ))
+                break
+    return hits
+
+
+# ---------- banners & report ----------
+
+BANNER_BEGIN = "<!-- DOCS-DRIFT:BEGIN -->"
+BANNER_END = "<!-- DOCS-DRIFT:END -->"
+_BANNER_RE = re.compile(
+    re.escape(BANNER_BEGIN) + r".*?" + re.escape(BANNER_END) + r"\n*",
+    re.DOTALL,
+)
+
+
+def render_banner(hits: list[DocHit], run_iso: str) -> str:
+    by_pr: dict[int, list[DocHit]] = {}
+    for h in hits:
+        by_pr.setdefault(h.symbol.pr_number, []).append(h)
+    rows: list[str] = []
+    for pr_number in sorted(by_pr):
+        sample = by_pr[pr_number][0]
+        symbols = ", ".join(sorted({
+            f"`{h.symbol.name}`" for h in by_pr[pr_number]
+        }))
+        rows.append(
+            f"- **#{pr_number}** — {sample.symbol.pr_title}\n"
+            f"  symbols: {symbols}"
+        )
+    return (
+        f"{BANNER_BEGIN}\n"
+        f"> **Documentation drift detected** _(scanned {run_iso})_\n"
+        f">\n"
+        f"> The watcher matched API symbols that changed in recently merged "
+        f"PRs against this page. Confirm the page is still accurate, edit "
+        f"if needed, then remove this banner.\n"
+        f">\n"
+        + "\n".join(f"> {r}" for r in rows)
+        + f"\n{BANNER_END}\n\n"
+    )
+
+
+def apply_banner(doc_path: Path, banner: str) -> bool:
+    text = doc_path.read_text(encoding="utf-8")
+    stripped = _BANNER_RE.sub("", text)
+    new_text = banner + stripped
+    if new_text == text:
+        return False
+    doc_path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def render_report(
+    hits: list[DocHit], run_iso: str, prs: list[dict], since_iso: str | None
+) -> str:
+    by_doc: dict[str, list[DocHit]] = {}
+    for h in hits:
+        by_doc.setdefault(h.doc_path, []).append(h)
+    lines: list[str] = [
+        f"# Docs Drift Report — {run_iso[:10]}",
+        "",
+        "_Auto-generated by `scripts/docs_drift_watcher.py`._",
+        "",
+        f"- Scan window start: `{since_iso or 'beginning of time'}`",
+        f"- Scan run: `{run_iso}`",
+        f"- Merged PRs reviewed: **{len(prs)}**",
+        f"- Doc pages flagged: **{len(by_doc)}**",
+        f"- Symbol mentions: **{len(hits)}**",
+        "",
+        "## Flagged pages",
+        "",
+    ]
+    if not by_doc:
+        lines += [
+            "_No drift detected. Documentation is clean for this window._",
+            "",
+        ]
+    for doc, ds in sorted(by_doc.items()):
+        lines += [f"### `{doc}`", ""]
+        for h in ds:
+            lines.append(
+                f"- line {h.line_number} — `{h.symbol.name}` "
+                f"(PR #{h.symbol.pr_number} · {h.symbol.kind} in "
+                f"`{h.symbol.source_file}`): {h.excerpt}"
+            )
+        lines.append("")
+    lines += ["## Merged PRs scanned", ""]
+    for pr in prs:
+        lines.append(
+            f"- #{pr['number']} — [{pr['title']}]({pr['html_url']}) "
+            f"by @{pr['user']['login']}, merged {pr['merged_at']}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------- orchestration ----------
+
+def collect_symbols(
+    gh: GitHub,
+    repo: str,
+    prs: list[dict],
+    config: dict,
+) -> dict[str, Symbol]:
+    symbols_by_name: dict[str, Symbol] = {}
+    ignore: set[str] = set(config.get("ignore_symbols") or [])
+    min_len = int(config.get("min_symbol_length") or 4)
+    code_exts = tuple(config.get("code_extensions") or [".py"])
+    for pr in prs:
+        try:
+            files = gh.list_pr_files(repo, pr["number"])
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"[drift] skipping PR #{pr['number']}: {exc}",
+                file=sys.stderr,
+            )
+            continue
+        for f in files:
+            name = f.get("filename") or ""
+            if not name.endswith(code_exts):
+                continue
+            for sym_name, kind in extract_from_patch(name, f.get("patch")):
+                if kind != "route" and len(sym_name) < min_len:
+                    continue
+                if sym_name in ignore:
+                    continue
+                symbols_by_name.setdefault(
+                    sym_name,
+                    Symbol(
+                        name=sym_name,
+                        kind=kind,
+                        source_file=name,
+                        pr_number=pr["number"],
+                        pr_title=pr["title"],
+                        pr_url=pr["html_url"],
+                    ),
+                )
+    return symbols_by_name
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--repo", required=True, help="owner/name of source repo")
+    ap.add_argument("--docs-repo", default=None,
+                    help="owner/name of docs repo (defaults to --repo)")
+    ap.add_argument("--docs-root", default="docs")
+    ap.add_argument("--state", default=".docs-drift/state.json")
+    ap.add_argument("--config", default=".docs-drift/config.yml")
+    ap.add_argument("--report-dir", default="docs/_drift")
+    ap.add_argument("--output", default=".docs-drift/last-run.json")
+    ap.add_argument("--apply-banners", action="store_true")
+    ap.add_argument("--since", default=None)
+    ap.add_argument("--dry-run", action="store_true")
+    args = ap.parse_args(argv)
+
+    docs_root = Path(args.docs_root)
+    state_path = Path(args.state)
+    config_path = Path(args.config)
+    report_dir = Path(args.report_dir)
+
+    config = load_config(config_path)
+    state = load_state(state_path)
+    since_iso = args.since or state.get("last_run_utc")
+    since_pr = int(state.get("last_pr_number") or 0)
+
+    token = os.environ.get("GITHUB_TOKEN")
+    gh = GitHub(token)
+
+    run_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(
+        f"[drift] run={run_iso} repo={args.repo} "
+        f"since={since_iso} since_pr={since_pr}",
+        file=sys.stderr,
+    )
+
+    prs = gh.list_merged_prs(
+        args.repo,
+        base_branch=str(config.get("base_branch") or "main"),
+        since_iso=since_iso,
+        since_pr=since_pr,
+        max_prs=int(config.get("max_prs_per_run") or 50),
+    )
+    print(f"[drift] merged PRs in window: {len(prs)}", file=sys.stderr)
+
+    symbols_by_name = collect_symbols(gh, args.repo, prs, config)
+    print(
+        f"[drift] candidate symbols: {len(symbols_by_name)}",
+        file=sys.stderr,
+    )
+
+    all_hits: list[DocHit] = []
+    ignore_doc_prefixes = list(config.get("ignore_doc_paths") or [])
+    doc_globs = list(config.get("docs_globs") or ["**/*.md", "**/*.html"])
+    if symbols_by_name and docs_root.exists():
+        for doc in iter_docs(docs_root, doc_globs, ignore_doc_prefixes):
+            all_hits.extend(scan_doc(doc, symbols_by_name))
+
+    flagged_docs = sorted({h.doc_path for h in all_hits})
+    print(
+        f"[drift] doc hits: {len(all_hits)} across "
+        f"{len(flagged_docs)} pages",
+        file=sys.stderr,
+    )
+
+    if not args.dry_run:
+        report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / f"REPORT-{run_iso[:10]}.md"
+    if not args.dry_run:
+        report_path.write_text(
+            render_report(all_hits, run_iso, prs, since_iso),
+            encoding="utf-8",
+        )
+
+    touched_docs: list[str] = []
+    if args.apply_banners and all_hits and not args.dry_run:
+        by_doc: dict[str, list[DocHit]] = {}
+        for h in all_hits:
+            by_doc.setdefault(h.doc_path, []).append(h)
+        for doc_path, doc_hits in by_doc.items():
+            banner = render_banner(doc_hits, run_iso)
+            if apply_banner(Path(doc_path), banner):
+                touched_docs.append(doc_path)
+
+    new_state = {
+        "last_run_utc": run_iso,
+        "last_pr_number": max(
+            [pr["number"] for pr in prs] + [since_pr], default=since_pr
+        ),
+        "last_window_pr_count": len(prs),
+        "last_window_hits": len(all_hits),
+    }
+    if not args.dry_run:
+        save_state(state_path, new_state)
+
+    summary = {
+        "run_utc": run_iso,
+        "repo": args.repo,
+        "docs_repo": args.docs_repo or args.repo,
+        "since_utc": since_iso,
+        "since_pr": since_pr,
+        "merged_prs": [
+            {
+                "number": pr["number"],
+                "title": pr["title"],
+                "merged_at": pr["merged_at"],
+                "html_url": pr["html_url"],
+                "author": pr.get("user", {}).get("login"),
+            }
+            for pr in prs
+        ],
+        "symbols": [
+            {
+                "name": s.name,
+                "kind": s.kind,
+                "pr_number": s.pr_number,
+                "source_file": s.source_file,
+            }
+            for s in symbols_by_name.values()
+        ],
+        "hits": [
+            {
+                "doc": h.doc_path,
+                "line": h.line_number,
+                "symbol": h.symbol.name,
+                "pr": h.symbol.pr_number,
+                "excerpt": h.excerpt,
+            }
+            for h in all_hits
+        ],
+        "flagged_docs": flagged_docs,
+        "touched_docs": touched_docs,
+        "report_path": str(report_path),
+        "drift_detected": bool(all_hits),
+    }
+    if not args.dry_run:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output).write_text(
+            json.dumps(summary, indent=2) + "\n", encoding="utf-8"
+        )
+
+    if all_hits:
+        print(
+            f"[drift] DRIFT DETECTED — {len(all_hits)} hits, "
+            f"{len(touched_docs)} pages updated.",
+            file=sys.stderr,
+        )
+    else:
+        print("[drift] no drift detected.", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_docs_drift_watcher.py
+++ b/tests/test_docs_drift_watcher.py
@@ -128,6 +128,25 @@ class ScanDocTest(unittest.TestCase):
         self.assertEqual(hits[0].line_number, 2)
         self.assertIn("CorpusPipeline", hits[0].excerpt)
 
+    def test_route_symbols_match_without_word_boundaries(self) -> None:
+        sym = dd.Symbol(
+            name="/v1/matters",
+            kind="route",
+            source_file="api/routes.py",
+            pr_number=9,
+            pr_title="Route change",
+            pr_url="https://example.test/9",
+        )
+        with self._tmp() as tmp:
+            doc = tmp / "routes.md"
+            doc.write_text(
+                "Call GET /v1/matters for the list.\n"
+                "See v1/matters without a leading slash here.\n",
+                encoding="utf-8",
+            )
+            hits = dd.scan_doc(doc, {"/v1/matters": sym})
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0].line_number, 1)
 
     def _tmp(self):
         import tempfile, contextlib
@@ -141,6 +160,50 @@ class ScanDocTest(unittest.TestCase):
 
 
 class BannerTest(unittest.TestCase):
+    def test_banner_inserts_after_yaml_frontmatter(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            doc = Path(d) / "page.md"
+            doc.write_text(
+                "---\ntitle: API\n---\n\n# Body\n",
+                encoding="utf-8",
+            )
+            sym = dd.Symbol(
+                name="ingest_corpus",
+                kind="function",
+                source_file="scripts/x.py",
+                pr_number=3,
+                pr_title="Refactor",
+                pr_url="u",
+            )
+            hits = [dd.DocHit(str(doc), sym, 3, "# Body")]
+            banner = dd.render_banner(hits, "2026-05-21T13:17:00Z")
+            dd.apply_banner(doc, banner)
+            text = doc.read_text(encoding="utf-8")
+            self.assertTrue(text.startswith("---\ntitle: API\n---\n\n"))
+            self.assertIn(dd.BANNER_BEGIN, text)
+            self.assertLess(text.index("---"), text.index(dd.BANNER_BEGIN))
+
+    def test_banner_blockquote_prefixes_continuation_lines(self) -> None:
+        sym = dd.Symbol(
+            name="ingest_corpus",
+            kind="function",
+            source_file="scripts/x.py",
+            pr_number=12,
+            pr_title="Refactor",
+            pr_url="u",
+        )
+        banner = dd.render_banner(
+            [dd.DocHit("docs/x.md", sym, 1, "line")],
+            "2026-05-21T13:17:00Z",
+        )
+        for line in banner.splitlines():
+            if line.strip().startswith("symbols:"):
+                self.assertTrue(
+                    line.startswith("> "),
+                    f"continuation line missing blockquote: {line!r}",
+                )
+
     def test_banner_round_trip_is_idempotent(self) -> None:
         import tempfile
         with tempfile.TemporaryDirectory() as d:
@@ -194,6 +257,71 @@ class ConfigTest(unittest.TestCase):
             cfg = dd.load_config(p)
             self.assertEqual(cfg["min_symbol_length"], 8)
             self.assertEqual(cfg["ignore_symbols"], {"get", "set", "foo"})
+
+
+class ParseIsoTest(unittest.TestCase):
+    def test_normalizes_z_and_offset(self) -> None:
+        self.assertEqual(
+            dd.parse_iso_timestamp("2026-05-01T00:00:00Z"),
+            "2026-05-01T00:00:00Z",
+        )
+        self.assertEqual(
+            dd.parse_iso_timestamp("2026-05-01T00:00:00+00:00"),
+            "2026-05-01T00:00:00Z",
+        )
+
+    def test_invalid_since_exits(self) -> None:
+        with self.assertRaises(SystemExit):
+            dd.parse_iso_timestamp("not-a-date")
+
+
+class ListMergedPrsTest(unittest.TestCase):
+    def test_includes_late_merge_with_low_pr_number(self) -> None:
+        class StubGitHub(dd.GitHub):
+            def _request(self, url):
+                return [
+                    {
+                        "number": 200,
+                        "merged_at": "2026-05-20T12:00:00Z",
+                        "updated_at": "2026-05-20T12:00:00Z",
+                    },
+                    {
+                        "number": 5,
+                        "merged_at": "2026-05-21T10:00:00Z",
+                        "updated_at": "2026-05-21T10:00:00Z",
+                    },
+                ]
+
+        gh = StubGitHub(None)
+        prs = gh.list_merged_prs(
+            "owner/repo",
+            "main",
+            since_iso="2026-05-19T00:00:00Z",
+            max_prs=50,
+        )
+        numbers = [p["number"] for p in prs]
+        self.assertIn(5, numbers)
+        self.assertIn(200, numbers)
+
+
+class EscapeMarkdownTest(unittest.TestCase):
+    def test_escapes_link_breaking_characters(self) -> None:
+        escaped = dd.escape_markdown_inline("Fix [broken] (title)")
+        self.assertIn(r"\[", escaped)
+        report = dd.render_report(
+            [],
+            "2026-05-21T13:17:00Z",
+            [{
+                "number": 1,
+                "title": "Fix [broken] (title)",
+                "html_url": "https://example.test/1",
+                "merged_at": "2026-05-20T00:00:00Z",
+                "user": {"login": "bot*name"},
+            }],
+            None,
+        )
+        self.assertIn(r"Fix \[broken\]", report)
+        self.assertIn(r"bot\*name", report)
 
 
 class StateTest(unittest.TestCase):

--- a/tests/test_docs_drift_watcher.py
+++ b/tests/test_docs_drift_watcher.py
@@ -1,0 +1,246 @@
+"""Unit tests for scripts/docs_drift_watcher.py.
+
+Stdlib only. No network calls — the GitHub client is monkeypatched.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from scripts import docs_drift_watcher as dd  # noqa: E402
+
+
+class ExtractPythonSymbolsTest(unittest.TestCase):
+    def test_picks_up_public_functions_and_classes(self) -> None:
+        code = textwrap.dedent(
+            """
+            def ingest_corpus(path):
+                return path
+
+            async def stream_pages():
+                yield 1
+
+            class CorpusPipeline:
+                pass
+
+            def _private():
+                pass
+            """
+        )
+        out = set(dd.extract_python_symbols(code))
+        self.assertIn(("ingest_corpus", "function"), out)
+        self.assertIn(("stream_pages", "function"), out)
+        self.assertIn(("CorpusPipeline", "class"), out)
+        self.assertNotIn(("_private", "function"), out)
+
+    def test_unparseable_diff_falls_back_to_regex(self) -> None:
+        body = "def renamed_handler(arg):\n    # missing block tail\n"
+        out = set(dd._python_regex_fallback(body))
+        self.assertIn(("renamed_handler", "function"), out)
+
+
+class ExtractJsSymbolsTest(unittest.TestCase):
+    def test_export_forms(self) -> None:
+        code = textwrap.dedent(
+            """
+            export function buildTracker() {}
+            export const TRACKER_VERSION = 4;
+            export class TrackerHelper {}
+            function localHelper() {}
+            class privateThing {}
+            """
+        )
+        out = dict(dd.extract_js_symbols(code))
+        self.assertEqual(out.get("buildTracker"), "export")
+        self.assertEqual(out.get("TRACKER_VERSION"), "export")
+        self.assertEqual(out.get("TrackerHelper"), "export")
+        self.assertEqual(out.get("localHelper"), "function")
+        # lowercase-class is filtered by the regex
+        self.assertNotIn("privateThing", out)
+
+
+class ExtractRoutesTest(unittest.TestCase):
+    def test_route_patterns(self) -> None:
+        code = textwrap.dedent(
+            """
+            @app.route('/v1/matters')
+            def matters(): pass
+
+            app.get("/v2/cases/:id")
+            router.post('/internal/sync')
+            """
+        )
+        routes = {p for p, _ in dd.extract_routes(code)}
+        self.assertEqual(
+            routes,
+            {"/v1/matters", "/v2/cases/:id", "/internal/sync"},
+        )
+
+
+class ExtractFromPatchTest(unittest.TestCase):
+    def test_rename_appears_on_both_sides(self) -> None:
+        patch = (
+            "@@ -1,3 +1,3 @@\n"
+            "-def IngestPipeline():\n"
+            "+def CorpusPipeline():\n"
+            "     return 1\n"
+        )
+        names = {n for n, _ in dd.extract_from_patch("scripts/x.py", patch)}
+        # The diff fragments alone are unparseable, but the regex fallback
+        # still picks up both names.
+        self.assertTrue(
+            {"IngestPipeline", "CorpusPipeline"}.issubset(names),
+            f"expected both names in {names}",
+        )
+
+    def test_empty_patch_returns_nothing(self) -> None:
+        self.assertEqual(dd.extract_from_patch("x.py", None), [])
+        self.assertEqual(dd.extract_from_patch("x.py", ""), [])
+
+
+class ScanDocTest(unittest.TestCase):
+    def test_word_boundary_match_and_excerpt(self) -> None:
+        sym = dd.Symbol(
+            name="CorpusPipeline",
+            kind="class",
+            source_file="scripts/pipeline.py",
+            pr_number=482,
+            pr_title="Rename pipeline",
+            pr_url="https://example.test/482",
+        )
+        with self._tmp() as tmp:
+            doc = tmp / "page.md"
+            doc.write_text(
+                "intro line\n"
+                "Use `CorpusPipeline` to begin.\n"
+                "CorpusPipelineXYZ should NOT match.\n",
+                encoding="utf-8",
+            )
+            hits = dd.scan_doc(doc, {"CorpusPipeline": sym})
+        self.assertEqual(len(hits), 1)
+        self.assertEqual(hits[0].line_number, 2)
+        self.assertIn("CorpusPipeline", hits[0].excerpt)
+
+
+    def _tmp(self):
+        import tempfile, contextlib
+
+        @contextlib.contextmanager
+        def _ctx():
+            with tempfile.TemporaryDirectory() as d:
+                yield Path(d)
+
+        return _ctx()
+
+
+class BannerTest(unittest.TestCase):
+    def test_banner_round_trip_is_idempotent(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            doc = Path(d) / "page.md"
+            doc.write_text("# Page\n\nbody.\n", encoding="utf-8")
+            sym = dd.Symbol(
+                name="ingest_corpus",
+                kind="function",
+                source_file="scripts/x.py",
+                pr_number=12,
+                pr_title="Refactor",
+                pr_url="u",
+            )
+            hits = [dd.DocHit(str(doc), sym, 1, "# Page")]
+            banner = dd.render_banner(hits, "2026-05-21T13:17:00Z")
+            self.assertTrue(dd.apply_banner(doc, banner))
+            after_one = doc.read_text(encoding="utf-8")
+            # Re-applying replaces, not stacks.
+            banner2 = dd.render_banner(hits, "2026-05-22T13:17:00Z")
+            self.assertTrue(dd.apply_banner(doc, banner2))
+            after_two = doc.read_text(encoding="utf-8")
+            self.assertEqual(
+                after_one.count(dd.BANNER_BEGIN), 1,
+                "first apply produced exactly one banner",
+            )
+            self.assertEqual(
+                after_two.count(dd.BANNER_BEGIN), 1,
+                "second apply does not stack banners",
+            )
+            self.assertIn("2026-05-22", after_two)
+            self.assertNotIn("2026-05-21", after_two)
+
+
+class ConfigTest(unittest.TestCase):
+    def test_missing_config_uses_defaults(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            cfg = dd.load_config(Path(d) / "nope.yml")
+            self.assertIn(".py", cfg["code_extensions"])
+            self.assertIsInstance(cfg["ignore_symbols"], set)
+
+    def test_overrides_apply(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "config.yml"
+            p.write_text(
+                "min_symbol_length: 8\n"
+                "ignore_symbols: [get, set, foo]\n",
+                encoding="utf-8",
+            )
+            cfg = dd.load_config(p)
+            self.assertEqual(cfg["min_symbol_length"], 8)
+            self.assertEqual(cfg["ignore_symbols"], {"get", "set", "foo"})
+
+
+class StateTest(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "state.json"
+            self.assertIsNone(dd.load_state(p)["last_run_utc"])
+            dd.save_state(p, {
+                "last_run_utc": "2026-05-21T13:17:00Z",
+                "last_pr_number": 42,
+            })
+            loaded = json.loads(p.read_text(encoding="utf-8"))
+            self.assertEqual(loaded["last_pr_number"], 42)
+
+
+class CollectSymbolsTest(unittest.TestCase):
+    def test_collect_dedupes_and_attaches_pr_metadata(self) -> None:
+        class StubGitHub:
+            def list_pr_files(self, repo, pr_number):
+                if pr_number == 1:
+                    return [{
+                        "filename": "scripts/pipeline.py",
+                        "patch": (
+                            "@@ -1,1 +1,1 @@\n"
+                            "-def IngestPipeline():\n"
+                            "+def CorpusPipeline():\n"
+                        ),
+                    }]
+                return [{
+                    "filename": "docs/index.html",  # not a code file
+                    "patch": "+CorpusPipeline reference",
+                }]
+
+        prs = [
+            {"number": 1, "title": "Rename pipeline",
+             "html_url": "u/1", "merged_at": "2026-05-20T00:00:00Z"},
+            {"number": 2, "title": "Docs only",
+             "html_url": "u/2", "merged_at": "2026-05-20T01:00:00Z"},
+        ]
+        cfg = dd.load_config(Path("nonexistent"))
+        out = dd.collect_symbols(StubGitHub(), "owner/repo", prs, cfg)
+        self.assertIn("CorpusPipeline", out)
+        self.assertEqual(out["CorpusPipeline"].pr_number, 1)
+        # Symbols-only-in-docs-files do not enter the surface.
+        self.assertNotIn("docs", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this adds

A scheduled GitHub Action that keeps the documentation honest about
what the code actually does. Every day at **13:17 UTC** the workflow:

1. Reads the checkpoint in `.docs-drift/state.json`.
2. Lists every PR merged into `main` since that checkpoint.
3. Extracts API symbols (functions, classes, exports, HTTP routes)
   from each PR's unified diff — catching additions, removals, and
   renames in one pass.
4. Word-boundary matches every symbol against every page under `docs/`.
5. If anything is flagged: writes a dated drift report into
   `docs/_drift/`, drops an inline editor banner at the top of every
   flagged page, and opens (or refreshes) a single review PR on the
   stable `docs-drift/auto` branch.

The editor sees one rolling PR, with every flagged page in one diff
and a checklist of what to verify.

## Components

| Path | Role |
| --- | --- |
| `.github/workflows/docs-drift-watcher.yml` | Cron + manual dispatch + PR plumbing. |
| `scripts/docs_drift_watcher.py` | Single-file scanner, stdlib only. |
| `.docs-drift/config.yml` | Globs, ignore lists, thresholds. |
| `.docs-drift/state.json` | Last-run checkpoint (advances only on PR merge). |
| `.docs-drift/README.md` | Short pointer to the full design doc. |
| `docs/overview/docs-drift-watcher.md` | Full, elite documentation: problem, design, failure modes, alternatives considered. |
| `tests/test_docs_drift_watcher.py` | 12 unit tests covering extraction, matching, banners, config, state. |
| `.github/workflows/verify.yml` | Wires the new tests into the existing `Verify` job. |

## Design choices worth reviewing

- **Diff-based extraction.** A symbol counts as "touched" if it appears
  on a `+` or `-` line. That single decision is what makes renames
  visible (old name removed + new name added).
- **Stable rolling PR.** The workflow force-pushes the same
  `docs-drift/auto` branch every day, so unattended drift accumulates
  into one review surface instead of N noisy PRs.
- **State advances on merge, not on run.** The checkpoint lives in-repo
  and only moves forward when the watcher's PR is merged. No silent
  gaps if a drift PR sits open.
- **Stdlib only.** No `pip install` step. The script runs anywhere
  Python 3.10+ runs.

## Test plan

- [x] `python -m unittest tests.test_docs_drift_watcher` — 12/12 pass locally.
- [x] `python scripts/docs_drift_watcher.py --help` — argparse loads cleanly.
- [ ] Manual workflow dispatch with `since=2025-01-01T00:00:00Z` after merge to confirm end-to-end behavior against a real backlog.
- [ ] Confirm the resulting `docs-drift/auto` PR carries the expected report body and banner diffs.

## Notes for the reviewer

- The full architecture, configuration reference, and "why this design,
  not the alternatives" section are all in
  `docs/overview/docs-drift-watcher.md`. Start there if you want the
  long version.
- The existing `Verify` workflow now also runs
  `tests.test_docs_drift_watcher` — no other CI changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDdJy2i8xvmArQK6LBBdyz)_