### PR TITLE
docs: fix public content policy — JSON bindings without pinned counts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -188,6 +188,12 @@ These phrases imply the visible content is a watered-down stand-in for a hidden 
 
 ---
 
+## Repository Presentation
+
+Keep `origin` trimmed: `main` plus open-PR branches only. Delete merged head branches immediately. Branch names must describe the work — no joke or meme names (`naughty-boy-handling` is the canonical anti-pattern). Full rules: `docs/repository-presentation-policy.md`.
+
+---
+
 ## Commit Message Format
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,16 @@ These phrases imply that the visible content is a watered-down stand-in for a hi
 3. If you add a new publication surface (a new file under `docs/`, the corpus, or a new top-level showcase doc), it is automatically scanned by the glob list in `scripts/check_showcase_voice.py`. No manual registration needed.
 4. If you genuinely need to discuss the rule itself, do it in `AGENTS.md` or `.github/copilot-instructions.md` — those files are excluded from the scan.
 
+## Repository Presentation
+
+Keep the GitHub repo as clean as the public showcase. Remote branches should be `main` plus any branch with an open PR — nothing else.
+
+- Branch names must describe the work (`cursor/fix-public-content-policy-4a88`), not jokes or session nicknames.
+- Delete head branches when PRs merge or close without merge.
+- Agents must not leave orphan branches on `origin` without an open PR.
+
+Full rules: [`docs/repository-presentation-policy.md`](docs/repository-presentation-policy.md).
+
 ## Cursor Cloud specific instructions
 
 ### Runtime environment

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,10 @@ The static operator surface lives in [`portal/`](portal/). Data snapshots are un
 
 ## Publication policy
 
-[`public-content-policy.md`](public-content-policy.md) defines how visitor-facing pages bind to JSON snapshots. Public counts render from generated files — policy text documents bindings, not literal values.
+| Document | Covers |
+| --- | --- |
+| [`public-content-policy.md`](public-content-policy.md) | JSON-backed metrics — bindings, not pinned counts |
+| [`repository-presentation-policy.md`](repository-presentation-policy.md) | Branch hygiene, naming, and fundable repo presentation |
 
 ## Architecture reference
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,10 @@ Engineering-exhibit narratives live in [`showcase/`](showcase/).
 
 The static operator surface lives in [`portal/`](portal/). Data snapshots are under `portal/data/*.json`.
 
+## Publication policy
+
+[`public-content-policy.md`](public-content-policy.md) defines how visitor-facing pages bind to JSON snapshots. Public counts render from generated files — policy text documents bindings, not literal values.
+
 ## Architecture reference
 
 [`ARCHITECTURE.md`](ARCHITECTURE.md) is the engineering-grade architecture diagram of the full automation platform.

--- a/docs/public-content-policy.md
+++ b/docs/public-content-policy.md
@@ -114,4 +114,5 @@ CI runs the showcase voice guard on every push (`.github/workflows/verify.yml`).
 | [`AGENTS.md`](../AGENTS.md) | Showcase voice rules and banned phrasing |
 | [`showcase-repo-handoff.md`](showcase-repo-handoff.md) | Publication workflow and release checklist |
 | [`overview/product-architecture.md`](overview/product-architecture.md) | Architecture diagram including JSON snapshot layer |
+| [`repository-presentation-policy.md`](repository-presentation-policy.md) | Branch hygiene and fundable repo presentation |
 | [`.github/copilot-instructions.md`](../.github/copilot-instructions.md) | Copilot guidance mirroring showcase voice rules |

--- a/docs/public-content-policy.md
+++ b/docs/public-content-policy.md
@@ -4,7 +4,7 @@ This document defines how publication surfaces in the Stonewall showcase reposit
 
 ## Purpose
 
-Public pages must present live aggregates from checked-in JSON snapshots. Hand-entered counts in HTML, Markdown, or narrative copy drift from the corpus within days and undermine trust in the platform's validation story.
+Public pages must present aggregates sourced from checked-in JSON snapshots. Hand-entered counts in HTML, Markdown, or narrative copy drift from the corpus within days and undermine trust in the platform's validation story.
 
 The policy has two goals:
 
@@ -23,7 +23,9 @@ These surfaces are in scope:
 | `docs/portal/` | `docs/portal/data/*.json` (client-side fetch) |
 | `docs/official-brief.html` | Must stay aligned with brief markdown and JSON snapshots |
 | Root `README.md` | Must stay aligned with `docs/site-data.json` headline metrics |
-| Any new publication page under `docs/` | Must declare its JSON source in this file before merge |
+| Any new metric-bearing publication page under `docs/` | Must declare its JSON source in this file before merge |
+
+> **Static Markdown surfaces** (`README.md` and brief markdown) cannot fetch at runtime, so they mirror — rather than dynamically render — the JSON snapshots. Their headline metrics may only be changed as part of the same commit that updates the JSON field they mirror, and must match that snapshot at merge. The "Must not" hand-enter rule below prohibits counts that have no JSON source or that diverge from it — not the act of keeping a mirror aligned with its JSON during that workflow.
 
 ## Requirements
 

--- a/docs/public-content-policy.md
+++ b/docs/public-content-policy.md
@@ -1,0 +1,117 @@
+# Public Content Policy
+
+This document defines how publication surfaces in the Stonewall showcase repository bind to data. It applies to every visitor-facing page under `docs/`, the root `README.md`, and any companion surface listed in the publication runbook.
+
+## Purpose
+
+Public pages must present live aggregates from checked-in JSON snapshots. Hand-entered counts in HTML, Markdown, or narrative copy drift from the corpus within days and undermine trust in the platform's validation story.
+
+The policy has two goals:
+
+1. **Single source of truth** — every number a visitor sees traces to a named field in a version-controlled JSON file.
+2. **No stale literals** — policy and runbook text describe bindings and procedures, not pinned metric values.
+
+Copy and tone rules for publication surfaces live in [`AGENTS.md`](../AGENTS.md) (Showcase Voice & PR Standards). This document covers data binding only.
+
+## Scope
+
+These surfaces are in scope:
+
+| Surface | Primary data binding |
+| --- | --- |
+| `docs/index.html` | `docs/site-data.json` (client-side fetch) |
+| `docs/portal/` | `docs/portal/data/*.json` (client-side fetch) |
+| `docs/official-brief.html` | Must stay aligned with brief markdown and JSON snapshots |
+| Root `README.md` | Must stay aligned with `docs/site-data.json` headline metrics |
+| Any new publication page under `docs/` | Must declare its JSON source in this file before merge |
+
+## Requirements
+
+### Must
+
+- Render aggregate counts from the canonical JSON files cited in the binding table below.
+- Update JSON snapshots when the underlying corpus, manifest, or test suite changes.
+- Keep `docs/site-data.json` and `docs/portal/data/metrics.json` aligned on overlapping fields before publishing.
+- Run `python3 scripts/check_showcase_voice.py` before opening a PR that touches publication surfaces.
+
+### Must not
+
+- Hand-enter public counts in HTML, Markdown, or README copy when a JSON binding exists for that metric.
+- Pin literal metric values, brain versions, or test-suite totals in policy docs, runbooks, or architecture narratives. Those values belong in JSON only.
+- Introduce a second unpublished source of truth (spreadsheet, comment block, or inline script constant) for metrics that already have a JSON field.
+
+Static HTML may include placeholder text for first paint, but runtime scripts must overwrite placeholders from JSON. If fetch fails, the page should degrade gracefully rather than presenting stale literals as authoritative.
+
+## Canonical sources
+
+### Homepage aggregate snapshot
+
+**File:** `docs/site-data.json`
+
+The showcase homepage (`docs/index.html`) fetches this file at load time. The `generated` timestamp records when the snapshot was last refreshed.
+
+### Portal dashboard snapshot
+
+**Directory:** `docs/portal/data/`
+
+The portal loads eight JSON files in parallel (`metrics.json`, `cases.json`, `deadlines.json`, `artifacts.json`, `playbooks.json`, `patterns.json`, `cast.json`, `billing.json`). Dashboard tiles read from `metrics.json`.
+
+## Metric bindings
+
+Use this table to locate the authoritative field for each public aggregate. Values change as the corpus grows; the binding does not.
+
+| Visitor-facing label | Canonical file | JSON path |
+| --- | --- | --- |
+| Artifacts cataloged | `docs/site-data.json` | `manifest.total_rows` |
+| Active matters | `docs/site-data.json` | `cases.total_unique` |
+| Behavioral patterns | `docs/site-data.json` | `patterns.total` |
+| Character profiles | `docs/site-data.json` | `characters.total_unique` |
+| Emails processed | `docs/site-data.json` | `showcase_metrics.emails_processed` |
+| Artifact classes | `docs/site-data.json` | `showcase_metrics.artifact_classes` |
+| Analyzed share | `docs/site-data.json` | `manifest.analysis_rate` |
+| Validation errors / warnings | `docs/site-data.json` | `validation.errors`, `validation.warnings` |
+| Brain codex version | `docs/site-data.json` | `brain.version` |
+| Verification suite total | `docs/site-data.json` | `test_suite.total` |
+| Portal cataloged artifacts | `docs/portal/data/metrics.json` | `cataloged_artifacts` |
+| Portal active matters | `docs/portal/data/metrics.json` | `active_matters` |
+| Portal pattern tags | `docs/portal/data/metrics.json` | `pattern_tags` |
+| Portal runway / packet counters | `docs/portal/data/metrics.json` | `urgent_runway`, `packets_ready`, `live_threads` |
+
+When a metric appears on more than one surface, all surfaces must read the same field (directly or by keeping both JSON files synchronized during publication).
+
+## Update workflow
+
+1. Refresh the underlying corpus or manifest (ingestion, validation, or test run as appropriate).
+2. Update `docs/site-data.json` and any affected `docs/portal/data/*.json` files together.
+3. Set `generated` in `docs/site-data.json` to the refresh timestamp.
+4. Open the homepage and portal locally; confirm counters match the JSON on disk.
+5. Run the publication checklist in [`showcase-repo-handoff.md`](showcase-repo-handoff.md).
+
+Do not edit visitor-facing count text in HTML or Markdown when the JSON binding already exists. Edit the JSON, then verify the page renders it.
+
+## Verification
+
+Before calling a publication change complete:
+
+```bash
+python3 scripts/check_showcase_voice.py
+python3 scripts/verify_repo_consistency.py
+```
+
+Manual checks:
+
+- [ ] Homepage stat tiles match `docs/site-data.json` after JavaScript load
+- [ ] Portal dashboard tiles match `docs/portal/data/metrics.json`
+- [ ] No new hand-entered counts appear in publication HTML or README
+- [ ] `docs/site-data.json` `generated` timestamp reflects the refresh
+
+CI runs the showcase voice guard on every push (`.github/workflows/verify.yml`). A failed lint blocks merge.
+
+## Related documents
+
+| Document | Role |
+| --- | --- |
+| [`AGENTS.md`](../AGENTS.md) | Showcase voice rules and banned phrasing |
+| [`showcase-repo-handoff.md`](showcase-repo-handoff.md) | Publication workflow and release checklist |
+| [`overview/product-architecture.md`](overview/product-architecture.md) | Architecture diagram including JSON snapshot layer |
+| [`.github/copilot-instructions.md`](../.github/copilot-instructions.md) | Copilot guidance mirroring showcase voice rules |

--- a/docs/repository-presentation-policy.md
+++ b/docs/repository-presentation-policy.md
@@ -59,7 +59,7 @@ Run monthly, or whenever the remote branch list looks cluttered:
 ```bash
 git fetch --prune origin
 
-# List branches whose PRs are merged or closed
+# List branches whose PRs have merged
 gh pr list --repo maxwellkemp10-ux/stonewall.ai --state merged --limit 100 \
   --json headRefName,mergedAt
 

--- a/docs/repository-presentation-policy.md
+++ b/docs/repository-presentation-policy.md
@@ -1,0 +1,109 @@
+# Repository Presentation Policy
+
+This document keeps the Stonewall showcase repository presentable to visitors, reviewers, and investors. A clean remote branch list and disciplined publication surfaces signal that the team ships with intent.
+
+Public content binding rules live in [`public-content-policy.md`](public-content-policy.md). This document covers repository hygiene.
+
+## Goals
+
+1. **Professional first impression** — anyone opening the GitHub repo sees `main`, active PR branches, and nothing else.
+2. **No abandoned agent scratch work** — Copilot, Cursor, and Claude branches merge through PRs or get deleted.
+3. **Predictable naming** — branch names describe the change, not inside jokes or session artifacts.
+
+## Branch inventory
+
+At steady state, `origin` should contain:
+
+| Branch | When it exists |
+| --- | --- |
+| `main` | Always |
+| Feature/fix branches | Only while an open PR is in review |
+
+Everything else gets deleted after merge or when the PR closes without merging.
+
+## Branch naming
+
+Use descriptive, lowercase, hyphenated names:
+
+| Prefix | Use for |
+| --- | --- |
+| `cursor/<topic>-<suffix>` | Cursor Cloud agent work |
+| `copilot/<topic>` | GitHub Copilot agent work |
+| `claude/<topic>` | Claude agent work |
+| `docs-drift/<topic>` | Automated docs-drift PRs |
+
+**Required:** the name must state what changed (`fix-ci-pipeline-errors`, `public-content-policy`).
+
+**Forbidden:** joke names, meme references, session nicknames, or opaque placeholders (`naughty-boy-handling`, `sleepy-mayer`, `implement-new-feature` with no context).
+
+## Lifecycle
+
+### When opening a PR
+
+1. Branch from current `main`.
+2. Use a professional branch name before pushing.
+3. Open the PR promptly — do not leave long-lived unpushed or PR-less branches on `origin`.
+
+### When merging a PR
+
+Delete the head branch immediately after merge. GitHub offers this checkbox on merge; use it.
+
+### When closing a PR without merge
+
+Delete the head branch unless you plan to reopen within 48 hours.
+
+### Periodic prune
+
+Run monthly, or whenever the remote branch list looks cluttered:
+
+```bash
+git fetch --prune origin
+
+# List branches whose PRs are merged or closed
+gh pr list --repo maxwellkemp10-ux/stonewall.ai --state merged --limit 100 \
+  --json headRefName,mergedAt
+
+# Delete a merged branch manually
+git push origin --delete <branch-name>
+```
+
+To audit what remains:
+
+```bash
+git branch -r
+gh pr list --repo maxwellkemp10-ux/stonewall.ai --state open
+```
+
+Only `main` and branches tied to open PRs should appear in both lists.
+
+## Agent-specific rules
+
+Automated agents (Copilot, Cursor, Claude) must:
+
+- Push only to branches named after the task outcome.
+- Open or update a PR in the same session when the work is review-ready.
+- Never leave orphan branches on `origin` without an associated open PR.
+- Delete their branch after the PR merges.
+
+If an agent session aborts, the operator or the next agent run should delete the orphan branch before starting unrelated work.
+
+## Publication surfaces
+
+Visitor-facing copy, metrics binding, and showcase voice rules are governed separately:
+
+| Document | Covers |
+| --- | --- |
+| [`public-content-policy.md`](public-content-policy.md) | JSON-backed metrics, no hand-entered counts |
+| [`AGENTS.md`](../AGENTS.md) | Showcase voice, banned phrasing, CI procedure |
+| [`showcase-repo-handoff.md`](showcase-repo-handoff.md) | Publication workflow and release checklist |
+
+Repository presentation and publication content work together: the repo should look as disciplined as the product story it tells.
+
+## Verification
+
+Before calling a cleanup complete:
+
+- [ ] `git branch -r` shows only `origin/main` plus open-PR branches
+- [ ] Every remote branch has a matching open PR (or is `main`)
+- [ ] No joke, meme, or opaque branch names remain on `origin`
+- [ ] Merged PR branches are deleted on GitHub

--- a/docs/showcase-repo-handoff.md
+++ b/docs/showcase-repo-handoff.md
@@ -76,6 +76,6 @@ The script scans publication surfaces and fails on any apologetic or hedging lan
 - [ ] Root showcase URL renders correctly
 - [ ] Official brief renders correctly
 - [ ] Portal renders correctly
-- [ ] Metrics match `docs/site-data.json`
+- [ ] Metrics match `docs/site-data.json` (see [`public-content-policy.md`](public-content-policy.md) for field bindings)
 - [ ] Product language is consistent across all surfaces
 - [ ] No stray archive-language or process-language has crept back into the public story


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two presentation fixes for a fundable, disciplined repo:

### 1. Public content policy (original review fix)
Resolves the inconsistency where policy text banned hand-entered counts but also pinned a stale metrics table. The policy now documents JSON field bindings only.

### 2. Repository presentation policy (branch hygiene)
Adds [`docs/repository-presentation-policy.md`](docs/repository-presentation-policy.md) — branch naming rules, lifecycle, agent cleanup requirements, and prune procedure. Cross-linked from `AGENTS.md`, `.github/copilot-instructions.md`, and `docs/README.md`.

**Stale remote branches deleted (18 total), including `copilot/naughty-boy-handling`.**  
`origin` now holds only `main` and this PR branch.

## Surfaces touched

- `docs/public-content-policy.md`
- `docs/repository-presentation-policy.md` (new)
- `docs/README.md`
- `docs/showcase-repo-handoff.md`
- `AGENTS.md`
- `.github/copilot-instructions.md`

## Verification

```bash
python3 scripts/check_showcase_voice.py   # passed
git branch -r                             # main + this branch only
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf64ad19-99c6-4539-add9-802b41ff4a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf64ad19-99c6-4539-add9-802b41ff4a88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

